### PR TITLE
Fix bug in WritePlan by using self.init_description

### DIFF
--- a/actions/planner.py
+++ b/actions/planner.py
@@ -22,7 +22,7 @@ class Planner(BaseModel):
             next_task = self.next_task_details()
             return next_task
 
-        response = WritePlan(plan_chat_id=self.current_plan.plan_chat_id).run(init_description)
+        response = WritePlan(plan_chat_id=self.current_plan.plan_chat_id).run(self.init_description)
 
         logger.info(f"plan: {response}")
 


### PR DESCRIPTION
This PR resolves a `NameError: name 'init_description' is not defined` in the `Planner.plan` method. The original code called `WritePlan.run` with an undefined variable `init_description`, causing a runtime failure. The fix updates it to use `self.init_description`, which is defined as a field in the `Planner` class (defaulting to an empty string), ensuring the correct instance-specific value is passed.

Changes:
- Updated `response = WritePlan(plan_chat_id=self.current_plan.plan_chat_id).run(init_description)` to `response = WritePlan(plan_chat_id=self.current_plan.plan_chat_id).run(self.init_description)` in the `plan` method.

Impact:
- Without this fix, the `plan` method fails immediately when `current_task` is absent, preventing task planning from proceeding (e.g., `parse_tasks` and `next_task_details` wouldn’t execute).
- Using `self.init_description` aligns with the class design and avoids the NameError.

No tests were added in this commit, but I recommend testing with both default and customized `init_description` values to confirm the fix behaves as expected.